### PR TITLE
Correct version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bugsigdbr
-Version: 1.1.6
+Version: 1.1.7
 Title: R-side access to published microbial signatures from BugSigDB
 Authors@R: c(
     person(given = "Ludwig",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Ontology-based queries for experimental factors and body sites
   (new functions `getOntology` and `subsetByOntologies`)
 
-## Changes in version 1.1.6
+## Changes in version 1.1.7
 
 * `importBugSigDB` accepts Zenodo DOIs, Github hashes, or `devel` as version.
 


### PR DESCRIPTION
Needed to correct version from 1.1.6 to 1.1.7 since 1.1.6 was already on git.bioconductor.org.