### PR TITLE
Update default importBugSigDB to v1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bugsigdbr
-Version: 1.1.11
+Version: 1.1.12
 Title: R-side access to published microbial signatures from BugSigDB
 Authors@R: c(
     person(given = "Ludwig",

--- a/R/bugsigdb.R
+++ b/R/bugsigdb.R
@@ -17,7 +17,7 @@
 #'  df <- importBugSigDB()
 #'
 #' @export
-importBugSigDB <- function(version = "10.5281/zenodo.5819260", cache = TRUE) 
+importBugSigDB <- function(version = "10.5281/zenodo.6468009", cache = TRUE)
 {
     version <- tolower(version)
 

--- a/man/importBugSigDB.Rd
+++ b/man/importBugSigDB.Rd
@@ -4,7 +4,7 @@
 \alias{importBugSigDB}
 \title{Obtain published microbial signatures from bugsigdb.org}
 \usage{
-importBugSigDB(version = "10.5281/zenodo.5819260", cache = TRUE)
+importBugSigDB(version = "10.5281/zenodo.6468009", cache = TRUE)
 }
 \arguments{
 \item{version}{character. A Zenodo DOI, git commit hash, or "devel".


### PR DESCRIPTION
@lgeistlinger Do we need to update the NEWS.md file?

I've updated the default to point to the new files on Zenodo and bumped the version.

Close #30 