### PR TITLE
pass arguments from writeGMT to cat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bugsigdbr
-Version: 1.7.6
+Version: 1.7.7
 Title: R-side access to published microbial signatures from BugSigDB
 Authors@R: c(
     person(given = "Ludwig",

--- a/R/getSignatures.R
+++ b/R/getSignatures.R
@@ -310,6 +310,7 @@ extractTaxLevel <- function(sig,
 #' @param sigs A list of microbe signatures (character vectors of taxonomic
 #' IDs).
 #' @param gmt.file character. Path to output file in GMT format.
+#' @param ... Arguments passed on to cat()
 #' @return none, writes to file.
 #' @references
 #' GMT file format:
@@ -320,7 +321,7 @@ extractTaxLevel <- function(sig,
 #' writeGMT(sigs, gmt.file = "signatures.gmt")
 #' file.remove("signatures.gmt") 
 #' @export
-writeGMT <- function(sigs, gmt.file) {
+writeGMT <- function(sigs, gmt.file, ...) {
     # collapse set members to one tab separated string
     gs.strings <- vapply(sigs,
                          function(x) paste(x, collapse = "\t"),
@@ -337,7 +338,7 @@ writeGMT <- function(sigs, gmt.file) {
     all.str <- paste(all, "\n", sep = "")
 
     # write in gmt format
-    cat(all.str, file = gmt.file, sep = "")
+    cat(all.str, file = gmt.file, sep = "", ...)
 }
 
 .extractSigs <- function(sigdf, tax.id.type, tax.level, exact.tax.level)

--- a/man/writeGMT.Rd
+++ b/man/writeGMT.Rd
@@ -4,13 +4,15 @@
 \alias{writeGMT}
 \title{Write microbe signatures to file in GMT format}
 \usage{
-writeGMT(sigs, gmt.file)
+writeGMT(sigs, gmt.file, ...)
 }
 \arguments{
 \item{sigs}{A list of microbe signatures (character vectors of taxonomic
 IDs).}
 
 \item{gmt.file}{character. Path to output file in GMT format.}
+
+\item{...}{Arguments passed on to cat()}
 }
 \value{
 none, writes to file.


### PR DESCRIPTION
My use case is wanting to set `append=TRUE`. Should be fully reverse compatible.