### PR TITLE
Use BugSigDbExports v1.2.0

### DIFF
--- a/R/bugsigdb.R
+++ b/R/bugsigdb.R
@@ -37,10 +37,14 @@
 #' @return a \code{\link{data.frame}}.
 #' @references BugSigDB: \url{https://bugsigdb.org}
 #'
-#' Stable release: \url{https://doi.org/10.5281/zenodo.5606165}
+#' Stable release: \url{https://doi.org/10.5281/zenodo.10407666}
 #'
 #' Latest version (incl. not reviewed content): 
 #'      \url{https://github.com/waldronlab/BugSigDBExports}
+#'
+#' Version 1.1.0: \url{https://doi.org/10.5281/zenodo.6468009}
+#'
+#' Version 1.0.2: \url{https://doi.org/10.5281/zenodo.5904281}
 #'
 #' BugSigDBExports commits page:
 #'      \url{https://github.com/waldronlab/BugSigDBExports/commits/main}
@@ -49,7 +53,7 @@
 #'  df <- importBugSigDB()
 #'
 #' @export
-importBugSigDB <- function(version = "10.5281/zenodo.6468009", cache = TRUE)
+importBugSigDB <- function(version = "10.5281/zenodo.10407666", cache = TRUE)
 {
     version <- tolower(version)
 

--- a/R/getSignatures.R
+++ b/R/getSignatures.R
@@ -98,7 +98,7 @@ getSignatures <- function(df,
 #'
 #'  # Condition-specific meta-signatures from fecal samples, increased
 #'  # in conditions of study. Use taxonomic names instead of the default NCBI IDs:
-#'  df.feces <- df[df$`Body site` == "feces", ]
+#'  df.feces <- df[tolower(df$`Body site`) == "feces", ]
 #'  cond.meta.sigs <- getMetaSignatures(df.feces, column = "Condition", 
 #'                                      direction = "UP", tax.id.type = "taxname")
 #'

--- a/man/getMetaSignatures.Rd
+++ b/man/getMetaSignatures.Rd
@@ -59,7 +59,7 @@ interest
 
  # Condition-specific meta-signatures from fecal samples, increased
  # in conditions of study. Use taxonomic names instead of the default NCBI IDs:
- df.feces <- df[df$`Body site` == "feces", ]
+ df.feces <- df[tolower(df$`Body site`) == "feces", ]
  cond.meta.sigs <- getMetaSignatures(df.feces, column = "Condition", 
                                      direction = "UP", tax.id.type = "taxname")
 

--- a/man/importBugSigDB.Rd
+++ b/man/importBugSigDB.Rd
@@ -4,7 +4,7 @@
 \alias{importBugSigDB}
 \title{Obtain published microbial signatures from bugsigdb.org}
 \usage{
-importBugSigDB(version = "10.5281/zenodo.6468009", cache = TRUE)
+importBugSigDB(version = "10.5281/zenodo.10407666", cache = TRUE)
 }
 \arguments{
 \item{version}{character. A Zenodo DOI, git commit hash, or "devel".
@@ -57,10 +57,14 @@ SHA code of the export version you want to use.
 \references{
 BugSigDB: \url{https://bugsigdb.org}
 
-Stable release: \url{https://doi.org/10.5281/zenodo.5606165}
+Stable release: \url{https://doi.org/10.5281/zenodo.10407666}
 
 Latest version (incl. not reviewed content): 
      \url{https://github.com/waldronlab/BugSigDBExports}
+
+Version 1.1.0: \url{https://doi.org/10.5281/zenodo.6468009}
+
+Version 1.0.2: \url{https://doi.org/10.5281/zenodo.5904281}
 
 BugSigDBExports commits page:
      \url{https://github.com/waldronlab/BugSigDBExports/commits/main}

--- a/tests/testthat/test-getMetaSignatures.R
+++ b/tests/testthat/test-getMetaSignatures.R
@@ -1,5 +1,5 @@
 bsdb <- importBugSigDB()
-df.feces <- subset(bsdb, `Body site` == "feces")
+df.feces <- subset(bsdb, `Body site` == "Feces")
 bs.msigs <- getMetaSignatures(bsdb, "Body site")
 co.msigs <- getMetaSignatures(df.feces, "Condition")
 

--- a/tests/testthat/test-ontology.R
+++ b/tests/testthat/test-ontology.R
@@ -20,12 +20,13 @@ checkOnto <- function(onto, which = c("efo", "uberon"))
 
 checkSubset <- function(sdf, col, pos, neg)
 {
+    print(paste(pos,"and",neg))
     expect_true(is.data.frame(sdf))
     expect_true(nrow(sdf) > 0)
     rel.cols <- c("Body site", "Condition")
     expect_true(all(rel.cols %in% colnames(sdf)))
-    expect_true(all(pos %in% sdf[,col]))
-    expect_false(any(neg %in% sdf[,col]))
+    expect_true(all(tolower(pos) %in% tolower(sdf[,col])))
+    expect_false(any(tolower(neg) %in% tolower(sdf[,col])))
 } 
 
 test_that("getOntology", {


### PR DESCRIPTION
Associated with #49. Note this PR also has changes related to the change in capitalization present in v1.2.0 in BugSigDbExports in 3f6ee5cc06e4448da3ed6d674f7b3e68697c896e.