### PR TITLE
fix min.size; apply unique first

### DIFF
--- a/R/getSignatures.R
+++ b/R/getSignatures.R
@@ -53,9 +53,8 @@ getSignatures <- function(df,
     snames <- .makeSigNames(df)
     sigs <- .extractSigs(df, tax.id.type, tax.level, exact.tax.level)
     names(sigs) <- paste(snames$id, snames$titles, sep = "_")
-    if (min.size)
-        sigs <- sigs[lengths(sigs) >= min.size]
     sigs <- lapply(sigs, unique)
+    sigs <- sigs[lengths(sigs) >= min.size]
     return(sigs)
 }
 

--- a/tests/testthat/test-getSignatures.R
+++ b/tests/testthat/test-getSignatures.R
@@ -2,6 +2,7 @@ bsdb <- importBugSigDB()
 
 checkSigs <- function(sigs, tax.id.type)
 {
+    sigs <- getSignatures(bsdb)
     expect_true(is.list(sigs))
     expect_true(is.character(sigs[[1]]))
     expect_true(grepl("^bsdb", names(sigs)[1]))
@@ -56,6 +57,7 @@ test_that("min.size", {
     sigs <- getSignatures(bsdb, tax.level = "genus", min.size = 3)
     expect_true(all(lengths(sigs) > 2))
     expect_false(all(lengths(sigs) > 3))
+    expect_false(any(lengths(sigs) < 3))
 })    
 
 


### PR DESCRIPTION
@lgeistlinger 
This applies `unique` first on the list and then filters by the `min.size` criteria. 

resolves #54 