### PR TITLE
Fix getSignatures after Study ID uses PMID

### DIFF
--- a/R/getSignatures.R
+++ b/R/getSignatures.R
@@ -218,7 +218,7 @@ restrictTaxLevel <- function(df,
     df <- df[nna,]
 
     # extract signatures
-    is.study <- grepl("^Study [0-9]+$", df[["Study"]])
+    is.study <- grepl("^(Study )?[0-9]+$", df[["Study"]])
     is.exp <- grepl("^Experiment [0-9]+$", df[["Experiment"]])
     df <- df[is.study & is.exp, ]
 

--- a/R/getSignatures.R
+++ b/R/getSignatures.R
@@ -53,7 +53,7 @@ getSignatures <- function(df,
     df <- df[nna,]
 
     # extract signatures
-    is.study <- grepl("^Study [0-9]+$", df[["Study"]])
+    is.study <- grepl("^(Study )?[0-9]+$", df[["Study"]])
     is.exp <- grepl("^Experiment [0-9]+$", df[["Experiment"]])
     df <- df[is.study & is.exp, ]
     

--- a/tests/testthat/test-importBugSigDB.R
+++ b/tests/testthat/test-importBugSigDB.R
@@ -27,6 +27,8 @@ test_that("importBugSigDB from the edge (devel)", {
     bsdb <- bugsigdbr::importBugSigDB(version = "devel", cache = FALSE)
     url <- "https://tinyurl.com/3nvzm3fx"
     checkImport(bsdb, url, nrows = 5450)
+    expect_true(all(!is.na(bsdb$Study)))
+    expect_true(all(!is.na(bsdb$Condition)))
 })
 
 test_that("importBugSigDB from github hash", {


### PR DESCRIPTION
Accommodate PMID as Study ID and test that devel exports have nonNA values in Study and Condition.

- [ ] NEWS should be updated with the version bump.